### PR TITLE
Fix NNGP Memory Leak

### DIFF
--- a/R/updateEta.R
+++ b/R/updateEta.R
@@ -150,8 +150,8 @@ updateEta = function(Y,Z,Beta,iSigma,Eta,Lambda,Alpha, rLPar, X,Pi,dfPi,rL){
                    }
                    iUEta = iWs + tmp1
                    R = Matrix::chol(iUEta)
-                   tmp2 = solve(t(R), as.vector(t(fS))) + rnorm(nf*np[r])
-                   feta = solve(R, tmp2)
+                   tmp2 = Matrix::solve(t(R), as.vector(t(fS))) + rnorm(nf*np[r])
+                   feta = Matrix::solve(R, tmp2)
                    eta = matrix(feta,np[r],nf,byrow=TRUE)
                 },
                 "GPP" = {

--- a/R/updateEta.R
+++ b/R/updateEta.R
@@ -150,8 +150,8 @@ updateEta = function(Y,Z,Beta,iSigma,Eta,Lambda,Alpha, rLPar, X,Pi,dfPi,rL){
                    }
                    iUEta = iWs + tmp1
                    R = Matrix::chol(iUEta)
-                   tmp2 = backsolve(R, as.vector(t(fS)), transpose=TRUE) + rnorm(nf*np[r])
-                   feta = backsolve(R, tmp2)
+                   tmp2 = solve(t(R), as.vector(t(fS))) + rnorm(nf*np[r])
+                   feta = solve(R, tmp2)
                    eta = matrix(feta,np[r],nf,byrow=TRUE)
                 },
                 "GPP" = {


### PR DESCRIPTION
In `updateEta`, `backsolve` creates a memory leak as the sparse diagonal matrix is converted to a dense matrix. The `solve` function from the `Matrix` package automatically performs a `backsolve` routine if the matrix is a dtCMatrix (compressed sparse triangular matrix), but does not result in the matrix being converted to a dense matrix. Thus, this solves the memory leak. Tests performed indicate that the `solve` method produces identical results for Eta for any given `updateEta` call as the original `backsolve` method. I believe that the root of this problem is that `Matrix` does not have its own dedicated `backsolve` or `forwardsolve` method, as it is automatically assumed that this is the methodology used when the object is of class dtCMatrix.

Note also that `backsolve` is used in the Full spatial model. I have not played around with this part of the function, so it is possible that this is the appropriate function for the Full model. However, it may be worth future tests to determine whether this  also speeds up the calculations for a Full spatial method.