### PR TITLE
Create Hmsc default-value formulas in global environment

### DIFF
--- a/R/Hmsc.R
+++ b/R/Hmsc.R
@@ -112,9 +112,10 @@
 #' @export
 
 
-Hmsc = function(Y, XFormula=~., XData=NULL, X=NULL, XScale=TRUE,
-                XSelect=NULL,
-                XRRRData=NULL, XRRRFormula=~.-1, XRRR=NULL, ncRRR=2, XRRRScale=TRUE,
+Hmsc = function(Y, XFormula=as.formula("~.", env=globalenv()),
+                XData=NULL, X=NULL, XScale=TRUE, XSelect=NULL,
+                XRRRData=NULL, XRRRFormula=as.formula("~.-1", env=globalenv()),
+                XRRR=NULL, ncRRR=2, XRRRScale=TRUE,
                 YScale = FALSE, Loff=NULL,
                 studyDesign=NULL, ranLevels=NULL, ranLevelsUsed=names(ranLevels),
                 TrFormula=NULL, TrData=NULL, Tr=NULL, TrScale=TRUE,


### PR DESCRIPTION
This PR is a proposal to create the default-value formulas of `Hmsc` object in the global environment (e.g., changing `XFormula=~.` to `XFormula=as.formula("~.", env=globalenv())`). The reason is to avoid Hmsc namespace to be written in an RDS file when using the default values.

Thanks to @gtikhonov for the discussion on this issue.

Related to https://github.com/aniskhan25/hmsc-hpc/pull/2.

Demonstration code (based on [Hmsc-HPC example](https://github.com/aniskhan25/hmsc-hpc/blob/eefaa0e617fba55eaa42a00eff4499e5ab5787f6/examples/basic_example/example.Rmd)):
```R
library(Hmsc)

# Create Hmsc object with user-defined XFormula
m = Hmsc(Y=TD$Y,
         XData=TD$X, XFormula=~.,
         TrData=TD$Tr[,-1], TrFormula=~.,
         phyloTree=TD$phy,
         studyDesign=TD$studyDesign,
         ranLevels=list(plot=TD$rL1, sample=TD$rL2))
saveRDS(m, file="hmsc_set_xformula.rds")
saveRDS(m, file="ascii_hmsc_set_xformula.rds", ascii=TRUE, compress=FALSE)

# Create Hmsc object with the (same) default XFormula
m = Hmsc(Y=TD$Y,
         XData=TD$X,
         TrData=TD$Tr[,-1], TrFormula=~.,
         phyloTree=TD$phy,
         studyDesign=TD$studyDesign,
         ranLevels=list(plot=TD$rL1, sample=TD$rL2))
saveRDS(m, file="hmsc_default_xformula.rds")
saveRDS(m, file="ascii_hmsc_default_xformula.rds", ascii=TRUE, compress=FALSE)
```

The file sizes are quite different as the files with default XFormula contain also Hmsc namespace:
```raw
4.6K hmsc_set_xformula.rds
8.0K hmsc_default_xformula.rds

 24K ascii_hmsc_set_xformula.rds
 65K ascii_hmsc_default_xformula.rds
```

With the changes of this PR, the resulting files would be almost the same (ascii files allow easier to comparison).